### PR TITLE
Remove codacy badge from Readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,6 @@ ifdef::env-github,env-browser[:relfileprefix: docs/]
 https://travis-ci.org/se-edu/addressbook-level4[image:https://travis-ci.org/se-edu/addressbook-level4.svg?branch=master[Build Status]]
 https://ci.appveyor.com/project/damithc/addressbook-level4[image:https://ci.appveyor.com/api/projects/status/3boko2x2vr5cc3w2?svg=true[Build status]]
 https://coveralls.io/github/se-edu/addressbook-level4?branch=master[image:https://coveralls.io/repos/github/se-edu/addressbook-level4/badge.svg?branch=master[Coverage Status]]
-https://www.codacy.com/app/damith/addressbook-level4?utm_source=github.com&utm_medium=referral&utm_content=se-edu/addressbook-level4&utm_campaign=Badge_Grade[image:https://api.codacy.com/project/badge/Grade/fc0b7775cf7f4fdeaf08776f3d8e364a[Codacy Badge]]
 https://gitter.im/se-edu/Lobby[image:https://badges.gitter.im/se-edu/Lobby.svg[Gitter chat]]
 
 ifdef::env-github[]


### PR DESCRIPTION
To verify that auto-publishing of documentation works.

Steps to follow :
------------------
1. Trigger Travis to regenerate documentation. To do so, you need to push a new commit to the master branch of the fork. Suggested change: Remove the codacy badge from README.

2. Wait for Travis CI to finish running the build on your new commit.

3. Go to the URL https://<your-username-or-organization-name>.github.io/addressbook-level4/. You should see your README file displayed.